### PR TITLE
Adjustment on node: babel-cli, .prettierignore, and .flowconfig

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -7,6 +7,9 @@
 # Ignore compiled code.
 .*/lib/.*
 
+# Ignore node_modules
+.*/node_modules/*
+
 [include]
 
 [libs]

--- a/.flowconfig
+++ b/.flowconfig
@@ -7,8 +7,8 @@
 # Ignore compiled code.
 .*/lib/.*
 
-# Ignore node_modules
-.*/node_modules/*
+# Ignore problematic libs
+.*/node_modules/chalk/.*
 
 [include]
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kfstart",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Quick start for your JS/React projects",
   "bin": {
     "kfstart": "./bin/kfstart.js"

--- a/src/main.js
+++ b/src/main.js
@@ -52,6 +52,7 @@ const CONFIG = {
       'default.flowconfig': '.flowconfig',
       'default.gitignore': '.gitignore',
       'default.npmignore': '.npmignore',
+      'default.prettierignore': '.prettierignore',
       'flow-typed': '',
     },
     mkdir: ['lib', 'src', 'node_modules'],
@@ -61,7 +62,7 @@ const CONFIG = {
     packages: ['node-fetch'],
     devPackages: [
       // babel (without react)
-      'babel-core', 'babel-preset-es2015-native-generators', 'babel-preset-stage-2', 'babel-plugin-transform-class-properties', 'babel-plugin-transform-flow-strip-types', 'babel-plugin-syntax-flow',
+      'babel-cli', 'babel-core', 'babel-preset-es2015-native-generators', 'babel-preset-stage-2', 'babel-plugin-transform-class-properties', 'babel-plugin-transform-flow-strip-types', 'babel-plugin-syntax-flow',
       // eslint (without react)
       'eslint', 'babel-eslint', 'eslint-plugin-babel', 'eslint-plugin-flowtype',
       // flow

--- a/starter/node/default.flowconfig
+++ b/starter/node/default.flowconfig
@@ -1,9 +1,6 @@
 [ignore]
 # Ignore compiled code.
 <PROJECT_ROOT>/lib/.*
-# Ignore node_modules
-.*/node_modules/*
-
 
 [include]
 

--- a/starter/node/default.flowconfig
+++ b/starter/node/default.flowconfig
@@ -1,6 +1,9 @@
 [ignore]
 # Ignore compiled code.
 <PROJECT_ROOT>/lib/.*
+# Ignore node_modules
+.*/node_modules/*
+
 
 [include]
 

--- a/starter/node/default.prettierignore
+++ b/starter/node/default.prettierignore
@@ -1,0 +1,1 @@
+package.json


### PR DESCRIPTION
* Added missing `babel-cli` on `node` devDependency, used on `npm run build`, might be needed by `CI`

* Added `.prettierignore` on `node` with basic rule

* Adjusted `.flowconfig` on `node` to ignore `node_modules`